### PR TITLE
Redis returns false so its not null

### DIFF
--- a/Slim/Middleware/SessionRedis.php
+++ b/Slim/Middleware/SessionRedis.php
@@ -129,7 +129,7 @@ class Slim_Middleware_SessionRedis
 	{
 		$key = "{$this->settings['session.name']}:{$session_id}";
 		$session_data = $this->redis->get($key);
-		if ( $session_data === NULL ) {
+		if ( $session_data === NULL || !session_data ) {
 			return "";
 		}
 		$this->redis->session_stat[$key] = md5($session_data);


### PR DESCRIPTION
PHP version 7.2
redis returns false therefore the following warning might appear:
... session_start(): Failed to read session data: user ...